### PR TITLE
chore: Automate release from Sonatype staging repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: Publish
 
 on:
   release:
-    # We'll run this workflow when a new GitHub release is created
     types: [released]
 
 jobs:
@@ -18,17 +17,14 @@ jobs:
           distribution: adopt
           java-version: 11
 
-        # Builds the release artifacts of the library
       - name: Release build
         run: ./gradlew :env-picker:assembleRelease
 
-        # Generates other artifacts (javadocJar is optional)
       - name: Source jar and dokka
         run: ./gradlew androidSourcesJar javadocJar
 
-        # Runs upload, and then closes & releases the repository
       - name: Publish to MavenCentral
-        run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 #closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
# Description

Instead of manually closing and releasing the Sonatype staging repository with each release, this will happen automatically as part of the publishing pipeline.

## Type of change

- [ ] CI enhancement